### PR TITLE
clickhouse_plugin/hooks/clickhouse_hook: parameters logging truncated

### DIFF
--- a/clickhouse_plugin/__version__.py
+++ b/clickhouse_plugin/__version__.py
@@ -9,7 +9,7 @@ __title__ = 'clickhouse_plugin'
 __description__ = \
     'clickhouse_plugin - ' \
     'Airflow plugin to execute Clickhouse commands and queries'
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 __author__ = 'Viktor Taranenko'
 __author_email__ = 'viktor@samsungnext.com'
 __license__ = 'Apache 2.0'

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from clickhouse_driver import Client
 from clickhouse_driver.errors import ServerException, ErrorCodes
@@ -20,11 +20,11 @@ class ClientFromUrlTestCase(TestCase):
     def test_temp_table(self):
         hook = LocalClickHouseHook()
         temp_table_name = 'test_temp_table'
-        result = hook.run(f'''
-            CREATE TEMPORARY TABLE {temp_table_name} (test_field UInt8);
-            INSERT INTO {temp_table_name} VALUES (1,), (2,), (3,);
-            SELECT SUM(test_field) FROM {temp_table_name}
-        '''.split(';'))
+        result = hook.run((
+            f'CREATE TEMPORARY TABLE {temp_table_name} (test_field UInt8)',
+            f'INSERT INTO {temp_table_name} VALUES (1,), (2,), (3,)',
+            f'SELECT SUM(test_field) FROM {temp_table_name}',
+        ))
         self.assertListEqual([(6,)], result)
         try:
             hook.run(f'SELECT * FROM {temp_table_name}')
@@ -32,3 +32,44 @@ class ClientFromUrlTestCase(TestCase):
             self.assertEqual(ErrorCodes.UNKNOWN_TABLE, err.code)
         else:
             raise AssertionError('server did not raise an error')
+
+
+class HookLogQueryTestCase(TestCase):
+    def setUp(self) -> None:
+        self.hook = LocalClickHouseHook()
+
+    def test_log_params(self):
+        self.assertEqual('{}', self.hook._log_params({}))
+        self.assertEqual("{1: 1}", self.hook._log_params({1: 1}))
+        self.assertEqual("{1: 1}", self.hook._log_params({1: 1}, limit=1))
+        self.assertEqual(
+            "{1: 1,… and 1 more parameters}",
+            self.hook._log_params({1: 1, 2: 2}, limit=1),
+        )
+        self.assertEqual(
+            "{1: 1, 2: 2}",
+            self.hook._log_params({1: 1, 2: 2}),
+        )
+        self.assertEqual(
+            "{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9,…"
+            " and 1 more parameters}",
+            self.hook._log_params({k: k for k in range(11)}),
+        )
+        self.assertEqual(
+            "{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9,…"
+            " and 10 more parameters}",
+            self.hook._log_params({k: k for k in range(20)}),
+        )
+        self.assertEqual(
+            "{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9,…"
+            " and 10 more parameters}",
+            self.hook._log_params({k: k for k in range(20)}, limit=10),
+        )
+
+    def test_log_query(self):
+        _ = self.hook.log  # to initialize .log property
+        with mock.patch.object(self.hook, '_log') as patched:
+            self.hook._log_query('SELECT 1', {})
+            patched.info.assert_called_with('%s%s', 'SELECT 1', ''),
+            self.hook._log_query('SELECT 1', {1: 1})
+            patched.info.assert_called_with('%s%s', 'SELECT 1', ' with {1: 1}')


### PR DESCRIPTION
Parameters are currently too spamming logs of Airflow. It is a problem for INSERT queries. the webpage with logs works too slow because of the logs volume (about 5 MB average). I reduced them to 10 parameters per log message maximum.