### PR TITLE
Add common-sql to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 clickhouse-driver~=0.2.0
 apache-airflow>=2.0.0,<2.5.0
+apache-airflow-providers-common-sql


### PR DESCRIPTION
A small change to add `apache-airflow-providers-common-sql` to `requirements.txt`.

Closes https://github.com/bryzgaloff/airflow-clickhouse-plugin/issues/53
