### PR TITLE
Adding query_id attr

### DIFF
--- a/airflow_clickhouse_plugin/hooks/clickhouse_hook.py
+++ b/airflow_clickhouse_plugin/hooks/clickhouse_hook.py
@@ -58,6 +58,7 @@ class ClickHouseHook(BaseHook):
             parameters: Union[None, dict, list, tuple, Generator] = None,
             with_column_types: bool = False,
             types_check: bool = False,
+            query_id: str = None
     ) -> Any:
         if isinstance(sql, str):
             sql = (sql,)
@@ -70,6 +71,7 @@ class ClickHouseHook(BaseHook):
                     params=parameters,
                     with_column_types=with_column_types,
                     types_check=types_check,
+                    query_id=query_id,
                 )
 
         return last_result

--- a/airflow_clickhouse_plugin/operators/clickhouse_operator.py
+++ b/airflow_clickhouse_plugin/operators/clickhouse_operator.py
@@ -18,6 +18,9 @@ class ClickHouseOperator(BaseOperator):
             clickhouse_conn_id: str = default_conn_name,
             parameters: Optional[Dict[str, Any]] = None,
             database: Optional[str] = None,
+            with_column_types: Optional[bool] = False,
+            types_check: Optional[bool] = False,
+            query_id: Optional[str] = None,
             *args,
             **kwargs,
     ):
@@ -26,10 +29,13 @@ class ClickHouseOperator(BaseOperator):
         self._conn_id = clickhouse_conn_id
         self._parameters = parameters
         self._database = database
+        self._with_column_types = with_column_types
+        self._types_check = types_check
+        self._query_id = query_id
 
     def execute(self, context: Dict[str, Any]) -> Any:
         hook = ClickHouseHook(
             clickhouse_conn_id=self._conn_id,
             database=self._database,
         )
-        return hook.run(self._sql, self._parameters)
+        return hook.run(self._sql, self._parameters, self._with_column_types, self._types_check, self._query_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-clickhouse-driver~=0.2.4
+clickhouse-driver~=0.2.0
 apache-airflow>=2.0.0,<2.7.0
 apache-airflow-providers-common-sql

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-clickhouse-driver~=0.2.0
+clickhouse-driver~=0.2.4
 apache-airflow>=2.0.0,<2.7.0
 apache-airflow-providers-common-sql

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -22,16 +22,20 @@ class ClickHouseOperatorTestCase(unittest.TestCase):
         clickhouse_conn_id = object()
         parameters = object()
         database = object()
+        with_column_types = object()
+        types_check = object()
+        query_id = object()
         op = ClickHouseOperator(
             task_id='_', sql=sql, clickhouse_conn_id=clickhouse_conn_id,
-            parameters=parameters, database=database,
+            parameters=parameters, database=database, with_column_types=with_column_types,
+            types_check=types_check, query_id=query_id,
         )
         op.execute(context=dict())
         clickhouse_hook_mock.assert_called_once_with(
             clickhouse_conn_id=clickhouse_conn_id,
             database=database,
         )
-        clickhouse_hook_mock().run.assert_called_once_with(sql, parameters)
+        clickhouse_hook_mock().run.assert_called_once_with(sql, parameters, with_column_types, types_check, query_id)
 
     @mock.patch(
         'airflow_clickhouse_plugin'
@@ -39,13 +43,14 @@ class ClickHouseOperatorTestCase(unittest.TestCase):
     )
     def test_defaults(self, clickhouse_hook_mock: mock.MagicMock):
         sql = 'SELECT 1'
-        op = ClickHouseOperator(task_id='_', sql=sql)
+        query_id = 'query_id test str'
+        op = ClickHouseOperator(task_id='_', sql=sql, with_column_types=False, types_check=False, query_id=query_id)
         op.execute(context=dict())
         clickhouse_hook_mock.assert_called_once_with(
             clickhouse_conn_id=ClickHouseHook.default_conn_name,
             database=None,
         )
-        clickhouse_hook_mock().run.assert_called_once_with(sql, None)
+        clickhouse_hook_mock().run.assert_called_once_with(sql, None, False, False, query_id)
 
     def test_template_fields_overrides(self):
         assert ClickHouseOperator.template_fields == ('_sql',)


### PR DESCRIPTION
To identify different queries with similar query_id or initial_query_id via system.query_log table you can have an ability to set query_id by yourself using query_id param in Airflow operators you using. 

It is possible by clickhouse-driver execute() method - https://clickhouse-driver.readthedocs.io/en/latest/api.html?highlight=query_id#clickhouse_driver.Client.execute_iter

This commit allows set query_id param as whatever you want, f.e. query_id = DAG_ID + TASK_ID + EXECUTION_DATE and then simply identify a query to build lineage. This can be helpful in situations when you manage equally named tables and the only way to identify their queries is to use a modfied query_id.