### PR TITLE
Support airflow 2.9.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1"]
+        airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1", "2.9.0"]
         airflow-extras: ["", "[common.sql]"]
         exclude:
           # constraints files for these combinations are missing
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1"]
+        airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1", "2.9.0"]
         airflow-extras: ["", "[common.sql]"]
         exclude:
           # constraints files for these combinations are missing

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Different versions of the plugin support different combinations of Python and Ai
 
 | airflow-clickhouse-plugin version | Airflow version         | Python version     |
 |-----------------------------------|-------------------------|--------------------|
-| 1.3.0                             | \>=2.0.0,<2.9.0         | ~=3.8              |
+| 1.3.0                             | \>=2.0.0,<2.10.0        | ~=3.8              |
 | 1.2.0                             | \>=2.0.0,<2.9.0         | ~=3.8              |
 | 1.1.0                             | \>=2.0.0,<2.8.0         | ~=3.8              |
 | 1.0.0                             | \>=2.0.0,<2.7.0         | ~=3.8              |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Different versions of the plugin support different combinations of Python and Ai
 
 | airflow-clickhouse-plugin version | Airflow version         | Python version     |
 |-----------------------------------|-------------------------|--------------------|
+| 1.3.0                             | \>=2.0.0,<2.9.0         | ~=3.8              |
 | 1.2.0                             | \>=2.0.0,<2.9.0         | ~=3.8              |
 | 1.1.0                             | \>=2.0.0,<2.8.0         | ~=3.8              |
 | 1.0.0                             | \>=2.0.0,<2.7.0         | ~=3.8              |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "airflow-clickhouse-plugin"
-version = "1.2.0"
+version = "1.3.0"
 description = "airflow-clickhouse-plugin — Airflow plugin to execute ClickHouse commands and queries"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -39,7 +39,7 @@ Issues = "https://github.com/bryzgaloff/airflow-clickhouse-plugin/issues"
 
 [project.optional-dependencies]
 "common.sql" = [
-    "apache-airflow[common.sql]>=2.2.0,<2.9.0",
+    "apache-airflow[common.sql]>=2.2.0,<2.10.0",
     "apache-airflow-providers-common-sql>=1.3.0",  # introduces SQLExecuteQueryOperator
     "clickhouse-driver>=0.2.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 clickhouse-driver~=0.2.0
-apache-airflow>=2.0.0,<2.9.0
+apache-airflow>=2.0.0,<2.10.0


### PR DESCRIPTION
Hi Anton!

Apache Airflow has a new release of 2.9.0 4 days ago.
I prepared PR for new versions for your plugin, pls take a look.
I already checked tests locally: https://github.com/epikhinm/airflow-clickhouse-plugin/actions/runs/8659553026 but let's see on your GHA also