### PR TITLE
Airflow 2.10 & python 3.12 support

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,7 +31,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install \
           -r requirements.txt \
-          --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.0/constraints-3.12.txt"
+          --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.0/constraints-3.12.txt"
     - name: Run tests on ClickHouse server
       env:
         AIRFLOW_CONN_CLICKHOUSE_DEFAULT: "clickhouse://localhost:${{ job.services.clickhouse.ports['9000'] }}"
@@ -106,8 +106,8 @@ jobs:
           python -m pip install \
             --index-url https://test.pypi.org/simple \
             --extra-index-url https://pypi.org/simple \
-            airflow-clickhouse-plugin[common.sql]==1.3.0 \
-            --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.0/constraints-3.12.txt"
+            airflow-clickhouse-plugin[common.sql]==1.4.0 \
+            --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.0/constraints-3.12.txt"
       - name: Run tests on ClickHouse server
         env:
           AIRFLOW_CONN_CLICKHOUSE_DEFAULT: "clickhouse://localhost:${{ job.services.clickhouse.ports['9000'] }}"
@@ -155,8 +155,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install \
-            airflow-clickhouse-plugin[common.sql]==1.3.0 \
-            --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.0/constraints-3.12.txt"
+            airflow-clickhouse-plugin[common.sql]==1.4.0 \
+            --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.0/constraints-3.12.txt"
       - name: Run tests on ClickHouse server
         env:
           AIRFLOW_CONN_CLICKHOUSE_DEFAULT: "clickhouse://localhost:${{ job.services.clickhouse.ports['9000'] }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1", "2.9.0"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1", "2.9.0", "2.10.0"]
         airflow-extras: ["", "[common.sql]"]
         exclude:
           # constraints files for these combinations are missing
@@ -50,6 +50,24 @@ jobs:
             airflow-version: "2.4.3"
           - python-version: "3.11"
             airflow-version: "2.5.3"
+          - python-version: "3.12"
+            airflow-version: "2.0.2"
+          - python-version: "3.12"
+            airflow-version: "2.1.4"
+          - python-version: "3.12"
+            airflow-version: "2.2.5"
+          - python-version: "3.12"
+            airflow-version: "2.3.4"
+          - python-version: "3.12"
+            airflow-version: "2.4.3"
+          - python-version: "3.12"
+            airflow-version: "2.5.3"
+          - python-version: "3.12"
+            airflow-version: "2.6.3"
+          - python-version: "3.12"
+            airflow-version: "2.7.1"
+          - python-version: "3.12"
+            airflow-version: "2.8.1"
           # common.sql constraint for these Airflow versions is <1.3.0
           #   => misses SQLExecuteQueryOperator
           - airflow-extras: "[common.sql]"
@@ -89,8 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1", "2.9.0"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1", "2.9.0", "2.10.0"]
         airflow-extras: ["", "[common.sql]"]
         exclude:
           # constraints files for these combinations are missing
@@ -112,6 +130,24 @@ jobs:
             airflow-version: "2.4.3"
           - python-version: "3.11"
             airflow-version: "2.5.3"
+          - python-version: "3.12"
+            airflow-version: "2.0.2"
+          - python-version: "3.12"
+            airflow-version: "2.1.4"
+          - python-version: "3.12"
+            airflow-version: "2.2.5"
+          - python-version: "3.12"
+            airflow-version: "2.3.4"
+          - python-version: "3.12"
+            airflow-version: "2.4.3"
+          - python-version: "3.12"
+            airflow-version: "2.5.3"
+          - python-version: "3.12"
+            airflow-version: "2.6.3"
+          - python-version: "3.12"
+            airflow-version: "2.7.1"
+          - python-version: "3.12"
+            airflow-version: "2.8.1"
           # common.sql constraint for these Airflow versions is <1.3.0
           #   => misses SQLExecuteQueryOperator
           - airflow-extras: "[common.sql]"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Different versions of the plugin support different combinations of Python and Ai
 
 | airflow-clickhouse-plugin version | Airflow version         | Python version     |
 |-----------------------------------|-------------------------|--------------------|
+| 1.4.0                             | \>=2.0.0,<2.11.0        | ~=3.8              |
 | 1.3.0                             | \>=2.0.0,<2.10.0        | ~=3.8              |
 | 1.2.0                             | \>=2.0.0,<2.9.0         | ~=3.8              |
 | 1.1.0                             | \>=2.0.0,<2.8.0         | ~=3.8              |
@@ -156,7 +157,7 @@ If you use a secure connection to ClickHouse (this requires additional configura
 ### ClickHouse connection schema
 
 [`clickhouse_driver.Client`][ch-driver-client] is initialized with attributes stored in Airflow [Connection attributes][airflow-connection-howto]:
-  
+
 | Airflow Connection attribute | `Client.__init__` argument |
 |------------------------------|----------------------------|
 | `host`                       | `host`                     |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "airflow-clickhouse-plugin"
-version = "1.3.0"
+version = "1.4.0"
 description = "airflow-clickhouse-plugin — Airflow plugin to execute ClickHouse commands and queries"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -22,6 +22,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Plugins",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
@@ -39,7 +40,7 @@ Issues = "https://github.com/bryzgaloff/airflow-clickhouse-plugin/issues"
 
 [project.optional-dependencies]
 "common.sql" = [
-    "apache-airflow[common.sql]>=2.2.0,<2.10.0",
+    "apache-airflow[common.sql]>=2.2.0,<2.11.0",
     "apache-airflow-providers-common-sql>=1.3.0",  # introduces SQLExecuteQueryOperator
     "clickhouse-driver>=0.2.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 clickhouse-driver~=0.2.0
-apache-airflow>=2.0.0,<2.10.0
+apache-airflow>=2.0.0,<2.11.0


### PR DESCRIPTION
Hi!

Added support of recently released Airflow 2.10 (and therefore Python 3.12), please take a look.