### PR TITLE
fix: MRO Issue in operator/clickhouse_dbapi

### DIFF
--- a/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
+++ b/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
@@ -27,56 +27,56 @@ class ClickHouseBaseDbApiOperator(ClickHouseDbApiHookMixin, sql.BaseSQLOperator)
 
 
 class ClickHouseSQLExecuteQueryOperator(
-    ClickHouseBaseDbApiOperator,
     sql.SQLExecuteQueryOperator,
+    ClickHouseBaseDbApiOperator,
 ):
     pass
 
 
 class ClickHouseSQLColumnCheckOperator(
-    ClickHouseBaseDbApiOperator,
     sql.SQLColumnCheckOperator,
+    ClickHouseBaseDbApiOperator,
 ):
     pass
 
 
 class ClickHouseSQLTableCheckOperator(
-    ClickHouseBaseDbApiOperator,
     sql.SQLTableCheckOperator,
+    ClickHouseBaseDbApiOperator,
 ):
     pass
 
 
 class ClickHouseSQLCheckOperator(
-    ClickHouseBaseDbApiOperator,
     sql.SQLCheckOperator,
+    ClickHouseBaseDbApiOperator,
 ):
     pass
 
 
 class ClickHouseSQLValueCheckOperator(
-    ClickHouseBaseDbApiOperator,
     sql.SQLValueCheckOperator,
+    ClickHouseBaseDbApiOperator,
 ):
     pass
 
 
 class ClickHouseSQLIntervalCheckOperator(
-    ClickHouseBaseDbApiOperator,
     sql.SQLIntervalCheckOperator,
+    ClickHouseBaseDbApiOperator,
 ):
     pass
 
 
 class ClickHouseSQLThresholdCheckOperator(
-    ClickHouseBaseDbApiOperator,
     sql.SQLThresholdCheckOperator,
+    ClickHouseBaseDbApiOperator,
 ):
     pass
 
 
 class ClickHouseBranchSQLOperator(
-    ClickHouseBaseDbApiOperator,
     sql.BranchSQLOperator,
+    ClickHouseBaseDbApiOperator,
 ):
     pass


### PR DESCRIPTION
This PR addresses a method resolution order (MRO) issue in the ClickHouse.*Operator implementations. 

For example `ClickHouseBranchSQLOperator`, due to the current inheritance order, parameters intended for the sql.BranchSQLOperator (such as follow_task_ids_if_true, follow_task_ids_if_false, and parameters) are not being correctly processed. This results in an “Invalid arguments” error when the operator is instantiated.

## Background

The operator is defined as follows:

```py
class ClickHouseBranchSQLOperator(
    sql.BranchSQLOperator,
    ClickHouseBaseDbApiOperator,
):
    pass
```

Because of Python’s MRO, the __init__ method from ClickHouseBaseDbApiOperator (or its parent, BaseSQLOperator) is encountered before sql.BranchSQLOperator.__init__. As a result, any branch-specific parameters are not recognized, leading to failures when those parameters are passed during instantiation.