### PR TITLE
Add OpenLineage support to ClickHouseDbApiHook

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1", "2.9.0", "2.10.0", "3.0.0", "3.1.0"]
         airflow-extras: ["", "[common.sql]"]
+        tests-pattern: ["-p test_clickhouse.py", "-p test_clickhouse_dbapi.py"]
         exclude:
           # constraints files for these combinations are missing
           - python-version: "3.10"
@@ -83,10 +84,12 @@ jobs:
           - airflow-extras: "[common.sql]"
             airflow-version: "2.4.3"
         include:
-          - airflow-extras: "[common.sql]"
-            tests-pattern: ""
           - airflow-extras: ""
             tests-pattern: "-p test_clickhouse.py"
+          - airflow-extras: "[common.sql]"
+            tests-pattern: "-p test_clickhouse_dbapi.py"
+          - airflow-extras: "[common,sql,openlineage]"
+            tests-pattern: "-p test_clickhouse_dbapi_openlineage.py"
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         airflow-version: ["2.0.2", "2.1.4", "2.2.5", "2.3.4", "2.4.3", "2.5.3", "2.6.3", "2.7.1", "2.8.1", "2.9.0", "2.10.0", "3.0.0", "3.1.0"]
-        airflow-extras: ["", "[common.sql]"]
+        airflow-extras: ["", "[common.sql,openlineage]"]
         exclude:
           # constraints files for these combinations are missing
           - python-version: "3.10"
@@ -72,19 +72,21 @@ jobs:
             airflow-version: "3.1.0"
           # common.sql constraint for these Airflow versions is <1.3.0
           #   => misses SQLExecuteQueryOperator
-          - airflow-extras: "[common.sql]"
+          - airflow-extras: "[common.sql,openlineage]"
             airflow-version: "2.0.2"
-          - airflow-extras: "[common.sql]"
+          - airflow-extras: "[common.sql,openlineage]"
             airflow-version: "2.1.4"
-          - airflow-extras: "[common.sql]"
+          - airflow-extras: "[common.sql,openlineage]"
             airflow-version: "2.2.5"
-          - airflow-extras: "[common.sql]"
+          - airflow-extras: "[common.sql,openlineage]"
             airflow-version: "2.3.4"
-          - airflow-extras: "[common.sql]"
+          - airflow-extras: "[common.sql,openlineage]"
             airflow-version: "2.4.3"
         include:
-          - airflow-extras: "[common.sql]"
+          # run all tests when all extras are installed
+          - airflow-extras: "[common.sql,openlineage]"
             tests-pattern: ""
+          # without any extras installed, run only clickhouse-driver native tests
           - airflow-extras: ""
             tests-pattern: "-p test_clickhouse.py"
     steps:

--- a/src/airflow_clickhouse_plugin/hooks/clickhouse_dbapi.py
+++ b/src/airflow_clickhouse_plugin/hooks/clickhouse_dbapi.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import clickhouse_driver
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
@@ -10,7 +12,7 @@ class ClickHouseDbApiHook(DbApiHook):
     clickhouse_conn_id: str  # set by DbApiHook.__init__
     default_conn_name = default_conn_name
 
-    def __init__(self, *args, schema: str = None, **kwargs):
+    def __init__(self, *args, schema: t.Optional[str] = None, **kwargs):
         super().__init__(*args, **kwargs)
         self._schema = schema
 
@@ -18,3 +20,16 @@ class ClickHouseDbApiHook(DbApiHook):
         airflow_conn = self.get_connection(self.clickhouse_conn_id)
         return clickhouse_driver.dbapi \
             .connect(**conn_to_kwargs(airflow_conn, self._schema))
+
+    def get_openlineage_database_info(self, connection):
+        from airflow.providers.openlineage.sqlparser import DatabaseInfo
+
+        authority = self.get_openlineage_authority_part(
+            connection,
+            default_port=9000,
+        )
+
+        return DatabaseInfo(scheme="clickhouse", authority=authority)
+
+    def get_openlineage_default_schema(self):
+        return self._schema or "default"

--- a/tests/unit/hooks/test_clickhouse_dbapi.py
+++ b/tests/unit/hooks/test_clickhouse_dbapi.py
@@ -3,8 +3,7 @@ from unittest import mock
 
 from airflow.models import Connection
 
-from airflow_clickhouse_plugin.hooks.clickhouse_dbapi import \
-    ClickHouseDbApiHook
+from airflow_clickhouse_plugin.hooks.clickhouse_dbapi import ClickHouseDbApiHook
 
 
 class ClickHouseDbApiHookTestCase(unittest.TestCase):
@@ -42,6 +41,33 @@ class ClickHouseDbApiHookTestCase(unittest.TestCase):
         ClickHouseDbApiHook().get_conn()
         self._get_connection_mock.assert_called_once_with('clickhouse_default')
         self._connect_mock.assert_called_once_with(host='localhost')
+
+    def test_get_openlineage_database_info(self):
+        try:
+            import airflow.providers.openlineage
+        except ImportError:
+            self.skipTest('airflow.providers.openlineage is not installed')
+
+        hook = ClickHouseDbApiHook()
+
+        conn = Connection(host='11.22.33.44', login='user', password='pass', schema='mydb')
+        database_info = hook.get_openlineage_database_info(conn)
+        self.assertEqual(database_info.scheme, 'clickhouse')
+        self.assertEqual(database_info.authority, '11.22.33.44:9000')
+
+        conn_with_port = Connection(host='11.22.33.44', port=9001, login='user', password='pass', schema='mydb')
+        database_info = hook.get_openlineage_database_info(conn_with_port)
+        self.assertEqual(database_info.scheme, 'clickhouse')
+        self.assertEqual(database_info.authority, '11.22.33.44:9001')
+
+    def test_get_openlineage_default_schema(self):
+        try:
+            import airflow.providers.openlineage
+        except ImportError:
+            self.skipTest('airflow.providers.openlineage is not installed')
+
+        self.assertEqual(ClickHouseDbApiHook().get_openlineage_default_schema(), 'default')
+        self.assertEqual(ClickHouseDbApiHook(schema='mydb').get_openlineage_default_schema(), 'mydb')
 
     def setUp(self) -> None:
         self._get_connection_patcher = \

--- a/tests/unit/hooks/test_clickhouse_dbapi_openlineage.py
+++ b/tests/unit/hooks/test_clickhouse_dbapi_openlineage.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest import mock
+
+from airflow.models import Connection
+
+from airflow_clickhouse_plugin.hooks.clickhouse_dbapi import ClickHouseDbApiHook
+
+
+class ClickHouseDbApiHookOpenLineageTestCase(unittest.TestCase):
+    def test_get_openlineage_database_info(self):
+        hook = ClickHouseDbApiHook()
+
+        conn = Connection(host='11.22.33.44', login='user', password='pass', schema='mydb')
+        database_info = hook.get_openlineage_database_info(conn)
+        self.assertEqual(database_info.scheme, 'clickhouse')
+        self.assertEqual(database_info.authority, '11.22.33.44:9000')
+
+        conn_with_port = Connection(host='11.22.33.44', port=9001, login='user', password='pass', schema='mydb')
+        database_info = hook.get_openlineage_database_info(conn_with_port)
+        self.assertEqual(database_info.scheme, 'clickhouse')
+        self.assertEqual(database_info.authority, '11.22.33.44:9001')
+
+    def test_get_openlineage_default_schema(self):
+        self.assertEqual(ClickHouseDbApiHook().get_openlineage_default_schema(), 'default')
+        self.assertEqual(ClickHouseDbApiHook(schema='mydb').get_openlineage_default_schema(), 'mydb')
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Airflow DbApiHook provides [several methods](https://github.com/apache/airflow/blob/d0e41dd35f0108324cab50aad8e310de9fffe382/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py#L1078-L1103) which enables [OpenLineage](https://openlineage.io/docs) integration. Using [PostgresHook](https://github.com/apache/airflow/blob/d0e41dd35f0108324cab50aad8e310de9fffe382/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py#L570-L585) as a reference.