### PR TITLE
Integration tests for DB API Operators

### DIFF
--- a/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
+++ b/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
@@ -22,6 +22,9 @@ class ClickHouseDbApiHookMixin(object):
 
 
 class ClickHouseBaseDbApiOperator(ClickHouseDbApiHookMixin, sql.BaseSQLOperator):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     def get_db_hook(self) -> ClickHouseDbApiHook:
         return self._get_clickhouse_db_api_hook(schema=self.database)
 
@@ -30,61 +33,53 @@ class ClickHouseSQLExecuteQueryOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLExecuteQueryOperator,
 ):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class ClickHouseSQLColumnCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLColumnCheckOperator,
 ):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class ClickHouseSQLTableCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLTableCheckOperator,
 ):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class ClickHouseSQLCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLCheckOperator,
 ):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class ClickHouseSQLValueCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLValueCheckOperator,
 ):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class ClickHouseSQLIntervalCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLIntervalCheckOperator,
 ):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class ClickHouseSQLThresholdCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLThresholdCheckOperator,
 ):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class ClickHouseBranchSQLOperator(
     ClickHouseBaseDbApiOperator,
     sql.BranchSQLOperator,
 ):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass

--- a/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
+++ b/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
@@ -30,53 +30,61 @@ class ClickHouseSQLExecuteQueryOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLExecuteQueryOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ClickHouseSQLColumnCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLColumnCheckOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ClickHouseSQLTableCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLTableCheckOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ClickHouseSQLCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLCheckOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ClickHouseSQLValueCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLValueCheckOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ClickHouseSQLIntervalCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLIntervalCheckOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ClickHouseSQLThresholdCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLThresholdCheckOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ClickHouseBranchSQLOperator(
     ClickHouseBaseDbApiOperator,
     sql.BranchSQLOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/tests/integration/operators/test_clickhouse.py
+++ b/tests/integration/operators/test_clickhouse.py
@@ -1,0 +1,22 @@
+import unittest
+from datetime import datetime
+
+from airflow import DAG
+
+from airflow_clickhouse_plugin.operators.clickhouse import (
+    ClickHouseOperator,
+)
+
+
+class ClickHouseOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseOperator(
+                task_id='test1',
+                sql='SELECT 1',
+            )
+            task.execute(context={})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/operators/test_clickhouse_dbapi.py
+++ b/tests/integration/operators/test_clickhouse_dbapi.py
@@ -1,0 +1,166 @@
+import unittest
+import unittest.mock
+from datetime import datetime, timedelta, timezone
+
+from airflow import DAG
+from airflow.models.dagrun import DagRun
+from airflow.operators.python import PythonOperator
+
+from airflow_clickhouse_plugin.operators.clickhouse_dbapi import (
+    ClickHouseBranchSQLOperator,
+    ClickHouseSQLCheckOperator,
+    ClickHouseSQLColumnCheckOperator,
+    ClickHouseSQLExecuteQueryOperator,
+    ClickHouseSQLIntervalCheckOperator,
+    ClickHouseSQLTableCheckOperator,
+    ClickHouseSQLThresholdCheckOperator,
+    ClickHouseSQLValueCheckOperator,
+)
+
+
+class ClickHouseSQLExecuteQueryOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLExecuteQueryOperator(
+                task_id='test-execute-query-operator',
+                conn_id=None,
+                sql='SELECT 1',
+            )
+            task.execute(context={})
+
+
+class ClickHouseSQLCheckOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLCheckOperator(
+                task_id='test-check-operator',
+                conn_id=None,
+                database='system',
+                sql='SELECT 1',
+            )
+            task.execute(context={})
+
+
+class ClickHouseSQLTableCheckOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLTableCheckOperator(
+                task_id='test-table-check-operator',
+                conn_id=None,
+                database='system',
+                table='one',
+                checks={
+                    'row_count_check': {'check_statement': 'COUNT(*) = 1'},
+                    'column_value_check': {'check_statement': 'dummy = 0'},
+                },
+            )
+            task.execute(context={})
+
+
+class ClickHouseSQLColumnCheckOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLColumnCheckOperator(
+                task_id='test-column-check-operator',
+                conn_id=None,
+                database='system',
+                table='one',
+                column_mapping={
+                    'dummy': {
+                        'null_check': {
+                            'equal_to': 0,
+                            'tolerance': 0,
+                        },
+                        'distinct_check': {
+                            'equal_to': 1,
+                        },
+                        'min': {
+                            'equal_to': 0,
+                        },
+                        'max': {
+                            'equal_to': 0,
+                        },
+                    }
+                },
+            )
+            task.execute(context={})
+
+
+class ClickHouseSQLValueCheckOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLValueCheckOperator(
+                task_id='test-value-check-operator',
+                conn_id=None,
+                sql='SELECT 1',
+                pass_value=1,
+                tolerance=0,
+            )
+            task.execute(context={})
+
+
+class ClickHouseSQLThresholdCheckOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLThresholdCheckOperator(
+                task_id='test-threshold-check-operator',
+                conn_id=None,
+                sql='SELECT 1',
+                min_threshold=1,
+                max_threshold=2,
+            )
+            task.execute(context={})
+
+
+class ClickHouseSQLIntervalCheckOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLIntervalCheckOperator(
+                task_id='test-interval-check-operator',
+                conn_id=None,
+                database='system',
+                table='metric_log',
+                date_filter_column='event_time_microseconds',
+                ignore_zero=True,
+                metrics_thresholds={'COUNT(*)': 0},
+            )
+
+            def ds_add(ds, days):
+                return ds + timedelta(days=days)
+
+            task.render_template_fields(
+                context={
+                    'ds': datetime.now(tz=timezone.utc),
+                    'macros': {'ds_add': ds_add},
+                }
+            )
+            task.execute(context={})
+
+
+class ClickHouseBranchSQLOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            branch_task = ClickHouseBranchSQLOperator(
+                task_id='test-branch-check-operator',
+                conn_id=None,
+                sql='SELECT 1',
+                follow_task_ids_if_true=['true_task'],
+                follow_task_ids_if_false=['false_task'],
+            )
+            PythonOperator(
+                task_id='true_task',
+                python_callable=lambda: 1,
+            )
+            PythonOperator(
+                task_id='false_task',
+                python_callable=lambda: 0,
+            )
+
+            task_instance = unittest.mock.Mock()
+            task_instance.task = branch_task
+            task_instance.get_dagrun.return_value = unittest.mock.Mock(spec=DagRun)
+            branch_task.execute(context={'ti': task_instance})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
https://github.com/bryzgaloff/airflow-clickhouse-plugin/pull/127#pullrequestreview-4077490035

> Could you please implement the idea I suggested in the https://github.com/bryzgaloff/airflow-clickhouse-plugin/pull/122? Add __init__ method to ClickHouseBaseDbApiOperator calling super().__init__ as-is. This should fix the resolution issue, I believe.

Tests are failing:
https://github.com/bryzgaloff/airflow-clickhouse-plugin/actions/runs/24280363410/job/70901195032?pr=130

Just as expected: https://github.com/bryzgaloff/airflow-clickhouse-plugin/pull/127#issuecomment-4208881895