### PR TITLE
DB API Airflow operators MRO fix: Invalid arguments were passed to ClickHouseSQLExecuteQueryOperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ Community contributors:
 * Daniil Parmon, [@dparmon](https://github.com/dparmon)
 * Behzod Mansurov, [@star-tek-mb](https://github.com/star-tek-mb)
 * Ward Gielis, [@wardgielis](https://github.com/wardgielis)
+* Maxim Martynov, [@dolfinus](https://github.com/dolfinus)
+* Rohith Reddy Kota, [@rohithreddykota](https://github.com/rohithreddykota)
 
 
 [airflow]: https://airflow.apache.org/

--- a/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
+++ b/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
@@ -25,6 +25,7 @@ class ClickHouseBaseDbApiOperator(
     ClickHouseDbApiHookMixin,
     sql.BaseSQLOperator,
 ):
+    # Explicitly define __init__ to prevent Airflow's BaseOperatorMeta from breaking MRO.
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
+++ b/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
@@ -21,7 +21,13 @@ class ClickHouseDbApiHookMixin(object):
         return ClickHouseDbApiHook(**hook_kwargs)
 
 
-class ClickHouseBaseDbApiOperator(ClickHouseDbApiHookMixin, sql.BaseSQLOperator):
+class ClickHouseBaseDbApiOperator(
+    ClickHouseDbApiHookMixin,
+    sql.BaseSQLOperator,
+):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     def get_db_hook(self) -> ClickHouseDbApiHook:
         return self._get_clickhouse_db_api_hook(schema=self.database)
 
@@ -30,7 +36,8 @@ class ClickHouseSQLExecuteQueryOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLExecuteQueryOperator,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ClickHouseSQLColumnCheckOperator(

--- a/tests/unit/operators/test_clickhouse_dbapi.py
+++ b/tests/unit/operators/test_clickhouse_dbapi.py
@@ -3,7 +3,14 @@ from unittest import mock
 
 from airflow_clickhouse_plugin.operators.clickhouse_dbapi import (
     ClickHouseBaseDbApiOperator,
+    ClickHouseBranchSQLOperator,
+    ClickHouseSQLCheckOperator,
+    ClickHouseSQLColumnCheckOperator,
     ClickHouseSQLExecuteQueryOperator,
+    ClickHouseSQLIntervalCheckOperator,
+    ClickHouseSQLTableCheckOperator,
+    ClickHouseSQLThresholdCheckOperator,
+    ClickHouseSQLValueCheckOperator,
 )
 
 
@@ -56,8 +63,137 @@ class ClickHouseSQLExecuteQueryOperatorTestCase(unittest.TestCase):
                 'output_processor': lambda x: x,
                 'requires_result_fetch': True,
             }
-            # task_id is required by BaseOperator
             ClickHouseSQLExecuteQueryOperator(task_id='test-task-id', **params)
+            mock_init.assert_called_once()
+            _, kwargs = mock_init.call_args
+            for name, value in params.items():
+                self.assertEqual(kwargs[name], value)
+
+
+class ClickHouseSQLColumnCheckOperatorTestCase(unittest.TestCase):
+    def test_init_arguments(self):
+        with mock.patch(
+            'airflow.providers.common.sql.operators.sql.SQLColumnCheckOperator.__init__',
+            return_value=None,
+        ) as mock_init:
+            params = {
+                'table': 'test_table',
+                'column_mapping': {'col1': {'null_check': {'equal_to': 0}}},
+                'partition_clause': 'id > 0',
+                'accept_none': False,
+            }
+            ClickHouseSQLColumnCheckOperator(task_id='test-task-id', **params)
+            mock_init.assert_called_once()
+            _, kwargs = mock_init.call_args
+            for name, value in params.items():
+                self.assertEqual(kwargs[name], value)
+
+
+class ClickHouseSQLTableCheckOperatorTestCase(unittest.TestCase):
+    def test_init_arguments(self):
+        with mock.patch(
+            'airflow.providers.common.sql.operators.sql.SQLTableCheckOperator.__init__',
+            return_value=None,
+        ) as mock_init:
+            params = {
+                'table': 'test_table',
+                'checks': {'row_count_check': {'check_statement': 'COUNT(*) = 1000'}},
+                'partition_clause': 'id > 0',
+            }
+            ClickHouseSQLTableCheckOperator(task_id='test-task-id', **params)
+            mock_init.assert_called_once()
+            _, kwargs = mock_init.call_args
+            for name, value in params.items():
+                self.assertEqual(kwargs[name], value)
+
+
+class ClickHouseSQLCheckOperatorTestCase(unittest.TestCase):
+    def test_init_arguments(self):
+        with mock.patch(
+            'airflow.providers.common.sql.operators.sql.SQLCheckOperator.__init__',
+            return_value=None,
+        ) as mock_init:
+            params = {
+                'sql': 'SELECT COUNT(*) FROM test_table',
+                'parameters': {'table': 'test_table'},
+            }
+            ClickHouseSQLCheckOperator(task_id='test-task-id', **params)
+            mock_init.assert_called_once()
+            _, kwargs = mock_init.call_args
+            for name, value in params.items():
+                self.assertEqual(kwargs[name], value)
+
+
+class ClickHouseSQLValueCheckOperatorTestCase(unittest.TestCase):
+    def test_init_arguments(self):
+        with mock.patch(
+            'airflow.providers.common.sql.operators.sql.SQLValueCheckOperator.__init__',
+            return_value=None,
+        ) as mock_init:
+            params = {
+                'sql': 'SELECT COUNT(*) FROM test_table',
+                'pass_value': 100,
+                'tolerance': 0.1,
+            }
+            ClickHouseSQLValueCheckOperator(task_id='test-task-id', **params)
+            mock_init.assert_called_once()
+            _, kwargs = mock_init.call_args
+            for name, value in params.items():
+                self.assertEqual(kwargs[name], value)
+
+
+class ClickHouseSQLIntervalCheckOperatorTestCase(unittest.TestCase):
+    def test_init_arguments(self):
+        with mock.patch(
+            'airflow.providers.common.sql.operators.sql.SQLIntervalCheckOperator.__init__',
+            return_value=None,
+        ) as mock_init:
+            params = {
+                'table': 'test_table',
+                'metrics_thresholds': {'count': 1.5},
+                'date_filter_column': 'created_at',
+                'days_back': -3,
+                'ratio_formula': 'relative_diff',
+                'ignore_zero': False,
+            }
+            ClickHouseSQLIntervalCheckOperator(task_id='test-task-id', **params)
+            mock_init.assert_called_once()
+            _, kwargs = mock_init.call_args
+            for name, value in params.items():
+                self.assertEqual(kwargs[name], value)
+
+
+class ClickHouseSQLThresholdCheckOperatorTestCase(unittest.TestCase):
+    def test_init_arguments(self):
+        with mock.patch(
+            'airflow.providers.common.sql.operators.sql.SQLThresholdCheckOperator.__init__',
+            return_value=None,
+        ) as mock_init:
+            params = {
+                'sql': 'SELECT COUNT(*) FROM test_table',
+                'min_threshold': 10,
+                'max_threshold': 1000,
+            }
+            ClickHouseSQLThresholdCheckOperator(task_id='test-task-id', **params)
+            mock_init.assert_called_once()
+            _, kwargs = mock_init.call_args
+            for name, value in params.items():
+                self.assertEqual(kwargs[name], value)
+
+
+class ClickHouseBranchSQLOperatorTestCase(unittest.TestCase):
+    def test_init_arguments(self):
+        with mock.patch(
+            'airflow.providers.common.sql.operators.sql.BranchSQLOperator.__init__',
+            return_value=None,
+        ) as mock_init:
+            params = {
+                'sql': 'SELECT 1',
+                'follow_task_ids_if_true': ['task_a', 'task_b'],
+                'follow_task_ids_if_false': ['task_c'],
+                'parameters': {'limit': 100},
+            }
+            ClickHouseBranchSQLOperator(task_id='test-task-id', **params)
             mock_init.assert_called_once()
             _, kwargs = mock_init.call_args
             for name, value in params.items():

--- a/tests/unit/operators/test_clickhouse_dbapi.py
+++ b/tests/unit/operators/test_clickhouse_dbapi.py
@@ -1,8 +1,10 @@
 import unittest
 from unittest import mock
 
-from airflow_clickhouse_plugin.operators.clickhouse_dbapi import \
-    ClickHouseBaseDbApiOperator
+from airflow_clickhouse_plugin.operators.clickhouse_dbapi import (
+    ClickHouseBaseDbApiOperator,
+    ClickHouseSQLExecuteQueryOperator,
+)
 
 
 class ClickHouseBaseDbApiOperatorTestCase(unittest.TestCase):
@@ -35,6 +37,14 @@ class ClickHouseBaseDbApiOperatorTestCase(unittest.TestCase):
 
     def tearDown(self):
         self._hook_cls_patcher.stop()
+
+
+class ClickHouseSQLExecuteQueryOperatorTestCase(unittest.TestCase):
+    def test_init(self):
+        ClickHouseSQLExecuteQueryOperator(
+            task_id='test-task-id',  # required by Airflow
+            sql='SELECT 1',
+        )
 
 
 if __name__ == '__main__':

--- a/tests/unit/operators/test_clickhouse_dbapi.py
+++ b/tests/unit/operators/test_clickhouse_dbapi.py
@@ -40,11 +40,28 @@ class ClickHouseBaseDbApiOperatorTestCase(unittest.TestCase):
 
 
 class ClickHouseSQLExecuteQueryOperatorTestCase(unittest.TestCase):
-    def test_init(self):
-        ClickHouseSQLExecuteQueryOperator(
-            task_id='test-task-id',  # required by Airflow
-            sql='SELECT 1',
-        )
+    def test_init_arguments(self):
+        with mock.patch(
+            'airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.__init__',
+            return_value=None,
+        ) as mock_init:
+            params = {
+                'sql': 'SELECT 1',
+                'autocommit': True,
+                'parameters': {'a': 1},
+                'handler': list,
+                'split_statements': True,
+                'return_last': True,
+                'show_return_value_in_logs': True,
+                'output_processor': lambda x: x,
+                'requires_result_fetch': True,
+            }
+            # task_id is required by BaseOperator
+            ClickHouseSQLExecuteQueryOperator(task_id='test-task-id', **params)
+            mock_init.assert_called_once()
+            _, kwargs = mock_init.call_args
+            for name, value in params.items():
+                self.assertEqual(kwargs[name], value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Issue: https://github.com/bryzgaloff/airflow-clickhouse-plugin/issues/131

The problem was originally raised in #93 by @rohithreddykota. Recently, it was updated in #131 and a number of related PRs by @dolfinus.

The issue required deeper investigation. Turned out the expected MRO did not work because of Airflow's metaclass. I have shared a detailed investigation report in this Medium article: https://medium.com/@bryzgaloff/how-airflows-metaclass-silently-breaks-python-mro-9f3d1c8629f8 (title: **How Airflow’s Metaclass Silently Breaks Python MRO**).

This PR combines efforts from all the contributors and fixes the MRO issues. Special thanks to @dolfinus for bringing this up and pushing the iterations 👏 