### PR TITLE
Fix ClickHouseSQLIntervalCheckOperator

### DIFF
--- a/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
+++ b/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
@@ -73,7 +73,46 @@ class ClickHouseSQLIntervalCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLIntervalCheckOperator,
 ):
-    pass
+    def __init__(
+        self,
+        *args,
+        table: str,
+        metrics_thresholds: t.Dict[str, int],
+        date_filter_column: t.Optional[str] = "ds",
+        days_back: int = -7,
+        ratio_formula: t.Optional[str] = "max_over_min",
+        ignore_zero: bool = True,
+        conn_id: t.Optional[str] = None,
+        database: t.Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            *args,
+            table=table,
+            metrics_thresholds=metrics_thresholds,
+            date_filter_column=date_filter_column,
+            days_back=days_back,
+            ratio_formula=ratio_formula,
+            ignore_zero=ignore_zero,
+            conn_id=conn_id,
+            database=database,
+            **kwargs,
+        )
+        # method internals were changed a bit between Airflow versions, this is a workaround
+        self.ratio_formula = ratio_formula
+        self.ignore_zero = ignore_zero
+        self.table = table
+        self.metrics_thresholds = metrics_thresholds
+        self.metrics_sorted = sorted(metrics_thresholds.keys())
+        self.date_filter_column = date_filter_column
+        self.days_back = -abs(days_back)
+        sqlexp = ", ".join(self.metrics_sorted)
+
+        # actual change
+        sqlt = f"SELECT {sqlexp} FROM {table} WHERE {date_filter_column}="
+        self.sql1 = f"{sqlt}parseDateTime64BestEffort('{{{{ ds }}}}', 6)"
+        self.sql2 = f"{sqlt}parseDateTime64BestEffort('{{{{ macros.ds_add(ds, {self.days_back}) }}}}', 6)"
+        self.sql: t.List[str] = [self.sql1, self.sql2]
 
 
 class ClickHouseSQLThresholdCheckOperator(

--- a/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
+++ b/src/airflow_clickhouse_plugin/operators/clickhouse_dbapi.py
@@ -2,8 +2,7 @@ import typing as t
 
 from airflow.providers.common.sql.operators import sql
 
-from airflow_clickhouse_plugin.hooks.clickhouse_dbapi import \
-    ClickHouseDbApiHook
+from airflow_clickhouse_plugin.hooks.clickhouse_dbapi import ClickHouseDbApiHook
 
 
 class ClickHouseDbApiHookMixin(object):
@@ -73,7 +72,41 @@ class ClickHouseSQLIntervalCheckOperator(
     ClickHouseBaseDbApiOperator,
     sql.SQLIntervalCheckOperator,
 ):
-    pass
+    def __init__(
+        self,
+        *args,
+        table: str,
+        metrics_thresholds: t.Dict[str, int],
+        date_filter_column: t.Optional[str] = "ds",
+        days_back: int = -7,
+        ratio_formula: t.Optional[str] = "max_over_min",
+        ignore_zero: bool = True,
+        conn_id: t.Optional[str] = None,
+        database: t.Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            *args,
+            table=table,
+            metrics_thresholds=metrics_thresholds,
+            date_filter_column=date_filter_column,
+            days_back=days_back,
+            ratio_formula=ratio_formula,
+            ignore_zero=ignore_zero,
+            conn_id=conn_id,
+            database=database,
+            **kwargs,
+        )
+        # parent class constructor internals can vary between Airflow versions,
+        # so we rely purely on input args
+        metrics_sorted = sorted(metrics_thresholds.keys())
+        days_back = -abs(days_back)
+        sqlexp = ", ".join(metrics_sorted)
+
+        sqlt = f"SELECT {sqlexp} FROM {table} WHERE {date_filter_column}="
+        self.sql1 = sqlt + "toDate('{{ ds }}')"
+        self.sql2 = sqlt + "toDate('{{ macros.ds_add(ds, " + str(days_back) + ") }}')"
+        self.sql: t.List[str] = [self.sql1, self.sql2]
 
 
 class ClickHouseSQLThresholdCheckOperator(

--- a/tests/integration/operators/test_clickhouse.py
+++ b/tests/integration/operators/test_clickhouse.py
@@ -1,0 +1,22 @@
+import unittest
+from datetime import datetime
+
+from airflow import DAG
+
+from airflow_clickhouse_plugin.operators.clickhouse import (
+    ClickHouseOperator,
+)
+
+
+class ClickHouseOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseOperator(
+                task_id='test1',
+                sql='SELECT 1',
+            )
+            task.execute(context={})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/operators/test_clickhouse_dbapi.py
+++ b/tests/integration/operators/test_clickhouse_dbapi.py
@@ -1,0 +1,38 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from airflow import DAG
+
+from airflow_clickhouse_plugin.operators.clickhouse_dbapi import (
+    ClickHouseSQLIntervalCheckOperator,
+)
+
+
+class ClickHouseSQLIntervalCheckOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLIntervalCheckOperator(
+                task_id='test-interval-check-operator',
+                conn_id=None,
+                database='system',
+                table='metric_log',
+                date_filter_column='event_time_microseconds',
+                ignore_zero=True,
+                metrics_thresholds={'COUNT(*)': 0},
+            )
+
+            def ds_add(ds, days):
+                return ds + timedelta(days=days)
+
+            task.render_template_fields(
+                context={
+                    'ds': datetime.now(tz=timezone.utc),
+                    'macros': {'ds_add': ds_add},
+                }
+            )
+            # no exception should be raised
+            task.execute(context={})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/operators/test_clickhouse_dbapi.py
+++ b/tests/integration/operators/test_clickhouse_dbapi.py
@@ -1,6 +1,5 @@
 import unittest
-import unittest.mock
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 
 from airflow import DAG
 
@@ -8,6 +7,7 @@ from airflow_clickhouse_plugin.operators.clickhouse_dbapi import (
     ClickHouseSQLCheckOperator,
     ClickHouseSQLColumnCheckOperator,
     ClickHouseSQLExecuteQueryOperator,
+    ClickHouseSQLIntervalCheckOperator,
     ClickHouseSQLTableCheckOperator,
     ClickHouseSQLThresholdCheckOperator,
     ClickHouseSQLValueCheckOperator,
@@ -32,7 +32,6 @@ class ClickHouseSQLCheckOperatorTestCase(unittest.TestCase):
             task = ClickHouseSQLCheckOperator(
                 task_id='test-check-operator',
                 conn_id=None,
-                database='system',
                 sql='SELECT 1',
             )
             # no exception should be raised
@@ -109,6 +108,36 @@ class ClickHouseSQLThresholdCheckOperatorTestCase(unittest.TestCase):
                 sql='SELECT 1',
                 min_threshold=1,
                 max_threshold=2,
+            )
+            # no exception should be raised
+            task.execute(context={})
+
+
+class ClickHouseSQLIntervalCheckOperatorTestCase(unittest.TestCase):
+    def test_execute(self):
+        with DAG('test_clickhouse_dbapi', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLIntervalCheckOperator(
+                task_id='test-interval-check-operator',
+                conn_id=None,
+                database='system',
+                table='metric_log',
+                date_filter_column='event_time_microseconds',
+                ignore_zero=True,
+                metrics_thresholds={'COUNT(*)': 0},
+            )
+
+            # https://github.com/apache/airflow/blob/3.2.1/task-sdk/src/airflow/sdk/execution_time/macros.py#L37-L52
+            def ds_add(ds, days):
+                if not days:
+                    return str(ds)
+                dt = datetime.strptime(str(ds), "%Y-%m-%d") + timedelta(days=days)
+                return dt.strftime("%Y-%m-%d")
+
+            task.render_template_fields(
+                context={
+                    'ds': date.today().strftime('%Y-%m-%d'),
+                    'macros': {'ds_add': ds_add},
+                }
             )
             # no exception should be raised
             task.execute(context={})

--- a/tests/unit/operators/test_clickhouse_dbapi.py
+++ b/tests/unit/operators/test_clickhouse_dbapi.py
@@ -1,5 +1,8 @@
 import unittest
+from datetime import datetime
 from unittest import mock
+
+from airflow import DAG
 
 from airflow_clickhouse_plugin.operators.clickhouse_dbapi import (
     ClickHouseBaseDbApiOperator,
@@ -161,6 +164,30 @@ class ClickHouseSQLIntervalCheckOperatorTestCase(unittest.TestCase):
             _, kwargs = mock_init.call_args
             for name, value in params.items():
                 self.assertEqual(kwargs[name], value)
+
+    def test_sql_queries(self):
+        with DAG('test_clickhouse', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLIntervalCheckOperator(
+                task_id='test-task-id',
+                conn_id=None,
+                database='mydb',
+                table='mytable',
+                date_filter_column='mycolumn',
+                ignore_zero=True,
+                metrics_thresholds={'col2': 2, 'col1': 1},
+            )
+            self.assertEqual(
+                task.sql1,
+                "SELECT col1, col2 "
+                "FROM mytable "
+                "WHERE mycolumn=parseDateTime64BestEffort('{{ ds }}', 6)",
+            )
+            self.assertEqual(
+                task.sql2,
+                "SELECT col1, col2 "
+                "FROM mytable "
+                "WHERE mycolumn=parseDateTime64BestEffort('{{ macros.ds_add(ds, -7) }}', 6)",
+            )
 
 
 class ClickHouseSQLThresholdCheckOperatorTestCase(unittest.TestCase):

--- a/tests/unit/operators/test_clickhouse_dbapi.py
+++ b/tests/unit/operators/test_clickhouse_dbapi.py
@@ -1,5 +1,8 @@
 import unittest
+from datetime import datetime
 from unittest import mock
+
+from airflow import DAG
 
 from airflow_clickhouse_plugin.operators.clickhouse_dbapi import (
     ClickHouseBaseDbApiOperator,
@@ -161,6 +164,30 @@ class ClickHouseSQLIntervalCheckOperatorTestCase(unittest.TestCase):
             _, kwargs = mock_init.call_args
             for name, value in params.items():
                 self.assertEqual(kwargs[name], value)
+
+    def test_sql_queries(self):
+        with DAG('test_clickhouse', start_date=datetime(2021, 1, 1)):
+            task = ClickHouseSQLIntervalCheckOperator(
+                task_id='test-task-id',
+                conn_id=None,
+                database='mydb',
+                table='mytable',
+                date_filter_column='mycolumn',
+                ignore_zero=True,
+                metrics_thresholds={'col2': 2, 'col1': 1},
+            )
+            self.assertEqual(
+                task.sql1,
+                "SELECT col1, col2 "
+                "FROM mytable "
+                "WHERE mycolumn=toDate('{{ ds }}')",
+            )
+            self.assertEqual(
+                task.sql2,
+                "SELECT col1, col2 "
+                "FROM mytable "
+                "WHERE mycolumn=toDate('{{ macros.ds_add(ds, -7) }}')",
+            )
 
 
 class ClickHouseSQLThresholdCheckOperatorTestCase(unittest.TestCase):


### PR DESCRIPTION
Without this change test was failing with exception:
```
======================================================================
ERROR: test_execute (__main__.ClickHouseSQLIntervalCheckOperatorTestCase.test_execute)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/clickhouse_driver/dbapi/cursor.py", line 111, in execute
    response = execute(
        operation, params=parameters, with_column_types=True,
        **execute_kwargs
    )
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/clickhouse_driver/client.py", line 382, in execute
    rv = self.process_ordinary_query(
        query, params=params, with_column_types=with_column_types,
    ...<2 lines>...
        columnar=columnar
    )
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/clickhouse_driver/client.py", line 580, in process_ordinary_query
    return self.receive_result(with_column_types=with_column_types,
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                               columnar=columnar)
                               ^^^^^^^^^^^^^^^^^^
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/clickhouse_driver/client.py", line 212, in receive_result
    return result.get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/clickhouse_driver/result.py", line 50, in get_result
    for packet in self.packet_generator:
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/clickhouse_driver/client.py", line 228, in packet_generator
    packet = self.receive_packet()
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/clickhouse_driver/client.py", line 245, in receive_packet
    raise packet.exception
clickhouse_driver.errors.ServerException: Code: 53.
DB::Exception: Cannot convert string '2026-03-30 20:06:07.461206+00:00' to type DateTime64(6): while executing function equals on arguments __table1.event_time_microseconds DateTime64(6) DateTime64(size = 0), '2026-03-30 20:06:07.461206+00:00'_String String Const(size = 0, String(size = 1)). Stack trace:

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x00000000133a985f
1. DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000c8549ce
2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000c854480
3. DB::Exception::Exception<String const&, String>(int, FormatStringHelperImpl<std::type_identity<String const&>::type, std::type_identity<String>::type>, String const&, String&&) @ 0x000000000d85612b
4. DB::(anonymous namespace)::convertFieldToTypeImpl(DB::Field const&, DB::IDataType const&, DB::IDataType const*, DB::FormatSettings const&) @ 0x00000000182ff06c
5. DB::convertFieldToType(DB::Field const&, DB::IDataType const&, DB::IDataType const*, DB::FormatSettings const&) @ 0x00000000182fbc64
6. DB::FunctionComparison<DB::EqualsOp, DB::NameEquals>::executeImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x000000000e85ae60
7. DB::IFunction::executeImplDryRun(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x000000000c85278a
8. DB::FunctionToExecutableFunctionAdaptor::executeDryRunImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x0000000015fd7c7a
9. DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000015fd01f8
10. DB::IExecutableFunction::executeWithoutSparseColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000015fd169e
11. DB::IExecutableFunction::execute(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000015fd2a3b
12. DB::ActionsDAG::evaluatePartialResult(std::unordered_map<DB::ActionsDAG::Node const*, DB::ColumnWithTypeAndName, std::hash<DB::ActionsDAG::Node const*>, std::equal_to<DB::ActionsDAG::Node const*>, std::allocator<std::pair<DB::ActionsDAG::Node const* const, DB::ColumnWithTypeAndName>>>&, std::vector<DB::ActionsDAG::Node const*, std::allocator<DB::ActionsDAG::Node const*>> const&, unsigned long, bool) @ 0x0000000017331591
13. DB::ActionsDAG::updateHeader(DB::Block const&) const @ 0x0000000017330079
14. DB::FilterTransform::transformHeader(DB::Block const&, DB::ActionsDAG const*, String const&, bool) @ 0x0000000019da662d
15. DB::FilterStep::FilterStep(std::shared_ptr<DB::Block const> const&, DB::ActionsDAG, String, bool) @ 0x0000000019fb96d3
16. std::__unique_if<DB::FilterStep>::__unique_single std::make_unique[abi:ne190107]<DB::FilterStep, std::shared_ptr<DB::Block const> const&, DB::ActionsDAG, String&, bool&>(std::shared_ptr<DB::Block const> const&, DB::ActionsDAG&&, String&, bool&) @ 0x000000001766b8ca
17. DB::(anonymous namespace)::addFilterStep(std::shared_ptr<DB::PlannerContext> const&, DB::QueryPlan&, DB::FilterAnalysisResult&, DB::SelectQueryOptions const&, String const&, std::unordered_set<std::shared_ptr<DB::FutureSet>, std::hash<std::shared_ptr<DB::FutureSet>>, std::equal_to<std::shared_ptr<DB::FutureSet>>, std::allocator<std::shared_ptr<DB::FutureSet>>>&) @ 0x00000000176684f7
18. DB::Planner::buildPlanForQueryNode() @ 0x000000001765e680
19. DB::Planner::buildQueryPlanIfNeeded() @ 0x0000000017658e1e
20. DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, std::unique_ptr<DB::ReadBuffer, std::default_delete<DB::ReadBuffer>>&, std::shared_ptr<DB::IAST>&, std::shared_ptr<DB::ImplicitTransactionControlExecutor>) @ 0x000000001833f091
21. DB::executeQuery(String const&, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) @ 0x00000000183378cb
22. DB::TCPHandler::runImpl() @ 0x00000000199fcf14
23. DB::TCPHandler::run() @ 0x0000000019a1ead8
24. Poco::Net::TCPServerConnection::start() @ 0x000000001ef38747
25. Poco::Net::TCPServerDispatcher::run() @ 0x000000001ef38bd9
26. Poco::PooledThread::run() @ 0x000000001eeff207
27. Poco::ThreadImpl::runnableEntry(void*) @ 0x000000001eefd601
28. ? @ 0x0000000000094ac3
29. ? @ 0x0000000000125a04


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/maxim/Repo/airflow-clickhouse-plugin/tests/integration/operators/test_clickhouse_dbapi.py", line 137, in test_execute
    task.execute(context={})
    ~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/airflow/sdk/bases/operator.py", line 417, in wrapper
    return func(self, *args, **kwargs)
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/airflow/providers/common/sql/operators/sql.py", line 1041, in execute
    row2 = hook.get_first(self.sql2)
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/airflow/providers/common/sql/hooks/sql.py", line 687, in get_first
    return self.run(sql=sql, parameters=parameters, handler=handlers.fetch_one_handler)
           ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/airflow/providers/common/sql/hooks/sql.py", line 818, in run
    self._run_command(cur, sql_statement, parameters)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/airflow/providers/common/sql/hooks/sql.py", line 869, in _run_command
    cur.execute(sql_statement)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/maxim/Repo/airflow-clickhouse-plugin/venv/lib/python3.13/site-packages/clickhouse_driver/dbapi/cursor.py", line 117, in execute
    raise OperationalError(orig)
clickhouse_driver.dbapi.errors.OperationalError: Code: 53.
DB::Exception: Cannot convert string '2026-03-30 20:06:07.461206+00:00' to type DateTime64(6): while executing function equals on arguments __table1.event_time_microseconds DateTime64(6) DateTime64(size = 0), '2026-03-30 20:06:07.461206+00:00'_String String Const(size = 0, String(size = 1)). Stack trace:

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x00000000133a985f
1. DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000c8549ce
2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000c854480
3. DB::Exception::Exception<String const&, String>(int, FormatStringHelperImpl<std::type_identity<String const&>::type, std::type_identity<String>::type>, String const&, String&&) @ 0x000000000d85612b
4. DB::(anonymous namespace)::convertFieldToTypeImpl(DB::Field const&, DB::IDataType const&, DB::IDataType const*, DB::FormatSettings const&) @ 0x00000000182ff06c
5. DB::convertFieldToType(DB::Field const&, DB::IDataType const&, DB::IDataType const*, DB::FormatSettings const&) @ 0x00000000182fbc64
6. DB::FunctionComparison<DB::EqualsOp, DB::NameEquals>::executeImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x000000000e85ae60
7. DB::IFunction::executeImplDryRun(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x000000000c85278a
8. DB::FunctionToExecutableFunctionAdaptor::executeDryRunImpl(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x0000000015fd7c7a
9. DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000015fd01f8
10. DB::IExecutableFunction::executeWithoutSparseColumns(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000015fd169e
11. DB::IExecutableFunction::execute(std::vector<DB::ColumnWithTypeAndName, std::allocator<DB::ColumnWithTypeAndName>> const&, std::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x0000000015fd2a3b
12. DB::ActionsDAG::evaluatePartialResult(std::unordered_map<DB::ActionsDAG::Node const*, DB::ColumnWithTypeAndName, std::hash<DB::ActionsDAG::Node const*>, std::equal_to<DB::ActionsDAG::Node const*>, std::allocator<std::pair<DB::ActionsDAG::Node const* const, DB::ColumnWithTypeAndName>>>&, std::vector<DB::ActionsDAG::Node const*, std::allocator<DB::ActionsDAG::Node const*>> const&, unsigned long, bool) @ 0x0000000017331591
13. DB::ActionsDAG::updateHeader(DB::Block const&) const @ 0x0000000017330079
14. DB::FilterTransform::transformHeader(DB::Block const&, DB::ActionsDAG const*, String const&, bool) @ 0x0000000019da662d
15. DB::FilterStep::FilterStep(std::shared_ptr<DB::Block const> const&, DB::ActionsDAG, String, bool) @ 0x0000000019fb96d3
16. std::__unique_if<DB::FilterStep>::__unique_single std::make_unique[abi:ne190107]<DB::FilterStep, std::shared_ptr<DB::Block const> const&, DB::ActionsDAG, String&, bool&>(std::shared_ptr<DB::Block const> const&, DB::ActionsDAG&&, String&, bool&) @ 0x000000001766b8ca
17. DB::(anonymous namespace)::addFilterStep(std::shared_ptr<DB::PlannerContext> const&, DB::QueryPlan&, DB::FilterAnalysisResult&, DB::SelectQueryOptions const&, String const&, std::unordered_set<std::shared_ptr<DB::FutureSet>, std::hash<std::shared_ptr<DB::FutureSet>>, std::equal_to<std::shared_ptr<DB::FutureSet>>, std::allocator<std::shared_ptr<DB::FutureSet>>>&) @ 0x00000000176684f7
18. DB::Planner::buildPlanForQueryNode() @ 0x000000001765e680
19. DB::Planner::buildQueryPlanIfNeeded() @ 0x0000000017658e1e
20. DB::executeQueryImpl(char const*, char const*, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, std::unique_ptr<DB::ReadBuffer, std::default_delete<DB::ReadBuffer>>&, std::shared_ptr<DB::IAST>&, std::shared_ptr<DB::ImplicitTransactionControlExecutor>) @ 0x000000001833f091
21. DB::executeQuery(String const&, std::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) @ 0x00000000183378cb
22. DB::TCPHandler::runImpl() @ 0x00000000199fcf14
23. DB::TCPHandler::run() @ 0x0000000019a1ead8
24. Poco::Net::TCPServerConnection::start() @ 0x000000001ef38747
25. Poco::Net::TCPServerDispatcher::run() @ 0x000000001ef38bd9
26. Poco::PooledThread::run() @ 0x000000001eeff207
27. Poco::ThreadImpl::runnableEntry(void*) @ 0x000000001eefd601
28. ? @ 0x0000000000094ac3
29. ? @ 0x0000000000125a04
```

So I've added explicit conversion from String to DateTime64 using `parseDateTime64BestEffort`. 
This requires at least Clickhouse v20.1.0.

Added unit & integration tests.